### PR TITLE
Fix echo usage in shell scripts

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -29,6 +29,6 @@ ninja -C "$TMP/build32" install
 install -m 755 "$SRC/tools/nine-install.sh" "$TMP/nine/"
 tar -C "$TMP" -czf "$TMP/nine.tar.gz" nine
 
-echo "\nenjoy your release: $TMP/nine.tar.gz\n"
+printf "\nenjoy your release: $TMP/nine.tar.gz\n"
 
 exit 0

--- a/tools/get_version.sh
+++ b/tools/get_version.sh
@@ -6,6 +6,6 @@ BUILD=0
 REVISION=`git rev-list --count HEAD 2>/dev/null || echo "0"`
 STAGE="devel"
 
-echo -n "$MAJOR.$MINOR.$BUILD.$REVISION-$STAGE"
+printf "$MAJOR.$MINOR.$BUILD.$REVISION-$STAGE"
 
 exit 0


### PR DESCRIPTION
Happens with `sh` symlinked to `dash` on Gentoo.